### PR TITLE
Upgrade webprotege-ipc to 1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>webprotege-ipc</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This allows us to specify a timeout for RabbitMQ with environment variables.