### PR TITLE
Add a per-project SSE stream registry and streaming endpoint

### DIFF
--- a/src/main/java/edu/stanford/protege/webprotege/gateway/SecurityConfig.java
+++ b/src/main/java/edu/stanford/protege/webprotege/gateway/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
@@ -63,6 +64,8 @@ public class SecurityConfig {
         http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/wsapps").permitAll()
+                        // The SSE controller enforces its own interim VIEW_PROJECT check (hardened by #305).
+                        .requestMatchers(HttpMethod.GET, "/data/projects/*/events").permitAll()
                         .anyRequest()
                         .authenticated()
                 );

--- a/src/main/java/edu/stanford/protege/webprotege/gateway/sse/LiveOnlySseCatchUpService.java
+++ b/src/main/java/edu/stanford/protege/webprotege/gateway/sse/LiveOnlySseCatchUpService.java
@@ -1,0 +1,22 @@
+package edu.stanford.protege.webprotege.gateway.sse;
+
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * Default {@link SseCatchUpService} that replays nothing: connections receive live events only.
+ * Reconnecting clients resume the live stream without recovering events missed while disconnected.
+ */
+@Component
+public class LiveOnlySseCatchUpService implements SseCatchUpService {
+
+    @Override
+    public void catchUp(ProjectId projectId,
+                        String lastEventId,
+                        SseEmitter emitter,
+                        ExecutionContext executionContext) {
+        // Live-only delivery: no history replay.
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/gateway/sse/ProjectEventsSseController.java
+++ b/src/main/java/edu/stanford/protege/webprotege/gateway/sse/ProjectEventsSseController.java
@@ -1,0 +1,97 @@
+package edu.stanford.protege.webprotege.gateway.sse;
+
+import edu.stanford.protege.webprotege.authorization.ProjectResource;
+import edu.stanford.protege.webprotege.authorization.Subject;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+import edu.stanford.protege.webprotege.gateway.websocket.AccessManager;
+import edu.stanford.protege.webprotege.gateway.websocket.dto.BuiltInCapability;
+import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import javax.annotation.Nullable;
+import java.util.UUID;
+
+/**
+ * Streams project-change events to a single viewer over a long-lived HTTP connection
+ * (server-sent events).
+ *
+ * <p>Interim authorization mirrors the STOMP {@code ProjectEventsInterceptor}: the caller passes
+ * {@code userId} and {@code token} query params and must hold {@code VIEW_PROJECT}. Identity
+ * resolution is isolated in {@link #resolveExecutionContext} so #305 can swap it for a short-lived
+ * redeemable ticket.
+ */
+@RestController
+public class ProjectEventsSseController {
+
+    static final String EVENTS_PATH = "/data/projects/{projectId}/events";
+
+    /** nginx-specific header that disables response buffering so events flush immediately. */
+    static final String X_ACCEL_BUFFERING = "X-Accel-Buffering";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProjectEventsSseController.class);
+
+    private static final String PROJECT_ID = "projectId";
+
+    private final SseStreamRegistry registry;
+
+    private final SseCatchUpService catchUpService;
+
+    private final AccessManager accessManager;
+
+    public ProjectEventsSseController(SseStreamRegistry registry,
+                                      SseCatchUpService catchUpService,
+                                      AccessManager accessManager) {
+        this.registry = registry;
+        this.catchUpService = catchUpService;
+        this.accessManager = accessManager;
+    }
+
+    @GetMapping(path = EVENTS_PATH, produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamEvents(@PathVariable(PROJECT_ID) ProjectId projectId,
+                                   @RequestParam("userId") String userId,
+                                   @RequestParam("token") String token,
+                                   @RequestParam(value = "lastEventId", required = false) String lastEventIdParam,
+                                   @RequestHeader(value = "Last-Event-ID", required = false) String lastEventIdHeader,
+                                   HttpServletResponse response) {
+        ExecutionContext executionContext = resolveExecutionContext(userId, token);
+        if (!accessManager.hasPermission(Subject.forUser(userId),
+                                         ProjectResource.forProject(projectId),
+                                         BuiltInCapability.VIEW_PROJECT,
+                                         executionContext)) {
+            LOGGER.info("Denied SSE stream: user {} lacks VIEW_PROJECT on project {}", userId, projectId.id());
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+                                              "User " + userId + " does not have access to project " + projectId.id());
+        }
+
+        // Browsers send Last-Event-ID only on automatic reconnects; fresh loads use the query param.
+        String lastEventId = (lastEventIdHeader != null) ? lastEventIdHeader : lastEventIdParam;
+
+        response.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
+        response.setHeader(X_ACCEL_BUFFERING, "no");
+
+        SseEmitter emitter = registry.subscribe(projectId, lastEventId, executionContext);
+        catchUpService.catchUp(projectId, lastEventId, emitter, executionContext);
+        return emitter;
+    }
+
+    /**
+     * Resolve the identity/authorization context from the connection's credentials. #305 replaces
+     * this interim query-param scheme with a redeemable, project-scoped ticket.
+     */
+    private ExecutionContext resolveExecutionContext(String userId, @Nullable String token) {
+        return new ExecutionContext(UserId.valueOf(userId), token, UUID.randomUUID().toString());
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/gateway/sse/SseCatchUpService.java
+++ b/src/main/java/edu/stanford/protege/webprotege/gateway/sse/SseCatchUpService.java
@@ -1,0 +1,29 @@
+package edu.stanford.protege.webprotege.gateway.sse;
+
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+/**
+ * Seam for replaying events a reconnecting client missed while it was disconnected.
+ *
+ * <p>The controller subscribes the emitter to live events first, then calls this service so a
+ * later change can replay from the durable history (identified by {@code lastEventId}) before the
+ * buffered live events flush. The live-only implementation shipped here does nothing.
+ */
+public interface SseCatchUpService {
+
+    /**
+     * Replay events that occurred after {@code lastEventId} onto {@code emitter}.
+     *
+     * @param projectId        the project whose events are streamed.
+     * @param lastEventId      the last event id the client already received, or {@code null} for a
+     *                         fresh connection with nothing to replay.
+     * @param emitter          the already-subscribed emitter to replay onto.
+     * @param executionContext the identity/authorization context resolved for this connection.
+     */
+    void catchUp(ProjectId projectId,
+                 String lastEventId,
+                 SseEmitter emitter,
+                 ExecutionContext executionContext);
+}

--- a/src/main/java/edu/stanford/protege/webprotege/gateway/sse/SseProperties.java
+++ b/src/main/java/edu/stanford/protege/webprotege/gateway/sse/SseProperties.java
@@ -1,0 +1,36 @@
+package edu.stanford.protege.webprotege.gateway.sse;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.time.Duration;
+
+/**
+ * Tunables for the server-sent events streaming endpoint.
+ *
+ * <p>The heartbeat interval must stay comfortably below the nginx {@code proxy_read_timeout}
+ * (60s by default) so idle streams are not dropped. The stream timeout closes long-lived
+ * connections so each reconnect becomes a fresh authorization checkpoint.
+ */
+@ConfigurationProperties(prefix = "webprotege.sse")
+public class SseProperties {
+
+    private Duration heartbeatInterval = Duration.ofSeconds(20);
+
+    private Duration streamTimeout = Duration.ofMinutes(30);
+
+    public Duration getHeartbeatInterval() {
+        return heartbeatInterval;
+    }
+
+    public void setHeartbeatInterval(Duration heartbeatInterval) {
+        this.heartbeatInterval = heartbeatInterval;
+    }
+
+    public Duration getStreamTimeout() {
+        return streamTimeout;
+    }
+
+    public void setStreamTimeout(Duration streamTimeout) {
+        this.streamTimeout = streamTimeout;
+    }
+}

--- a/src/main/java/edu/stanford/protege/webprotege/gateway/sse/SseStreamRegistry.java
+++ b/src/main/java/edu/stanford/protege/webprotege/gateway/sse/SseStreamRegistry.java
@@ -1,0 +1,199 @@
+package edu.stanford.protege.webprotege.gateway.sse;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+
+/**
+ * Holds the open server-sent event streams, keyed by project, and fans project-change events out
+ * to every stream watching that project.
+ *
+ * <p>Delivery never happens on the caller's thread: {@link #publish} hands each send to a dispatch
+ * executor, and the heartbeat scheduler enqueues its keep-alives on the same executor. Writes to a
+ * single emitter are serialized on the subscriber monitor so concurrent live sends and heartbeats
+ * cannot interleave and corrupt the stream. Any failed send evicts the dead emitter.
+ */
+@Component
+public class SseStreamRegistry {
+
+    /** SSE {@code event:} name; the client filters on this. Matches the STOMP payload contract. */
+    static final String EVENT_NAME = "project-events";
+
+    static final String HEARTBEAT_COMMENT = "keep-alive";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SseStreamRegistry.class);
+
+    private final ConcurrentMap<ProjectId, Set<Subscriber>> subscribersByProject = new ConcurrentHashMap<>();
+
+    private final ObjectMapper objectMapper;
+
+    private final SseProperties properties;
+
+    private final ExecutorService dispatchExecutor;
+
+    private final ScheduledExecutorService heartbeatExecutor;
+
+    @Autowired
+    public SseStreamRegistry(ObjectMapper objectMapper, SseProperties properties) {
+        this(objectMapper,
+             properties,
+             Executors.newCachedThreadPool(daemonThreadFactory("sse-dispatch")),
+             Executors.newSingleThreadScheduledExecutor(daemonThreadFactory("sse-heartbeat")));
+    }
+
+    SseStreamRegistry(ObjectMapper objectMapper,
+                      SseProperties properties,
+                      ExecutorService dispatchExecutor,
+                      ScheduledExecutorService heartbeatExecutor) {
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.dispatchExecutor = dispatchExecutor;
+        this.heartbeatExecutor = heartbeatExecutor;
+    }
+
+    @PostConstruct
+    void startHeartbeat() {
+        long intervalMillis = properties.getHeartbeatInterval().toMillis();
+        heartbeatExecutor.scheduleAtFixedRate(this::heartbeat, intervalMillis, intervalMillis, TimeUnit.MILLISECONDS);
+    }
+
+    @PreDestroy
+    void shutdown() {
+        heartbeatExecutor.shutdownNow();
+        dispatchExecutor.shutdownNow();
+    }
+
+    /**
+     * Open a stream for a viewer of {@code projectId} and register it for live delivery.
+     *
+     * @param lastEventId      the last event id the client already has (stored for reconnect
+     *                         catch-up), or {@code null} for a fresh connection.
+     * @param executionContext the identity/authorization context resolved for this connection.
+     */
+    public SseEmitter subscribe(ProjectId projectId,
+                                @Nullable String lastEventId,
+                                ExecutionContext executionContext) {
+        return register(projectId,
+                        new SseEmitter(properties.getStreamTimeout().toMillis()),
+                        lastEventId,
+                        executionContext);
+    }
+
+    SseEmitter register(ProjectId projectId,
+                        SseEmitter emitter,
+                        @Nullable String lastEventId,
+                        ExecutionContext executionContext) {
+        Subscriber subscriber = new Subscriber(emitter, lastEventId, executionContext);
+        subscribersByProject.compute(projectId, (key, existing) -> {
+            Set<Subscriber> set = (existing != null) ? existing : ConcurrentHashMap.newKeySet();
+            set.add(subscriber);
+            return set;
+        });
+        emitter.onCompletion(() -> remove(projectId, subscriber));
+        emitter.onTimeout(() -> {
+            emitter.complete();
+            remove(projectId, subscriber);
+        });
+        emitter.onError(error -> remove(projectId, subscriber));
+        return emitter;
+    }
+
+    /**
+     * Fan {@code payload} out to every stream watching {@code projectId}, stamped with
+     * {@code sequenceId} as the SSE {@code id:}. Returns immediately; sends run on the dispatch
+     * executor.
+     */
+    public void publish(ProjectId projectId, long sequenceId, Object payload) {
+        Set<Subscriber> subscribers = subscribersByProject.get(projectId);
+        if (subscribers == null || subscribers.isEmpty()) {
+            return;
+        }
+        String json;
+        try {
+            json = new String(objectMapper.writeValueAsBytes(payload), StandardCharsets.UTF_8);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to serialize SSE payload for project {}", projectId, e);
+            return;
+        }
+        String id = Long.toString(sequenceId);
+        for (Subscriber subscriber : subscribers) {
+            dispatchExecutor.execute(() -> deliver(projectId, subscriber, () -> SseEmitter.event()
+                    .id(id)
+                    .name(EVENT_NAME)
+                    .data(json, MediaType.APPLICATION_JSON)));
+        }
+    }
+
+    /** Send a keep-alive comment to every open stream; failed sends evict. Package-visible for tests. */
+    void heartbeat() {
+        subscribersByProject.forEach((projectId, subscribers) -> subscribers.forEach(subscriber ->
+                dispatchExecutor.execute(() -> deliver(projectId, subscriber,
+                        () -> SseEmitter.event().comment(HEARTBEAT_COMMENT)))));
+    }
+
+    private void deliver(ProjectId projectId, Subscriber subscriber, Supplier<SseEventBuilder> event) {
+        synchronized (subscriber) {
+            try {
+                subscriber.emitter().send(event.get());
+            } catch (Exception e) {
+                LOGGER.debug("Evicting unreachable SSE subscriber for project {}: {}", projectId, e.getMessage());
+                remove(projectId, subscriber);
+            }
+        }
+    }
+
+    private void remove(ProjectId projectId, Subscriber subscriber) {
+        subscribersByProject.computeIfPresent(projectId, (key, set) -> {
+            set.remove(subscriber);
+            return set.isEmpty() ? null : set;
+        });
+    }
+
+    int subscriberCount(ProjectId projectId) {
+        Set<Subscriber> subscribers = subscribersByProject.get(projectId);
+        return (subscribers == null) ? 0 : subscribers.size();
+    }
+
+    List<Subscriber> subscribersFor(ProjectId projectId) {
+        Set<Subscriber> subscribers = subscribersByProject.get(projectId);
+        return (subscribers == null) ? List.of() : new ArrayList<>(subscribers);
+    }
+
+    private static ThreadFactory daemonThreadFactory(String namePrefix) {
+        AtomicInteger counter = new AtomicInteger();
+        return runnable -> {
+            Thread thread = new Thread(runnable, namePrefix + "-" + counter.incrementAndGet());
+            thread.setDaemon(true);
+            return thread;
+        };
+    }
+
+    /** One open stream and the reconnect state needed to resume it. */
+    record Subscriber(SseEmitter emitter, @Nullable String lastEventId, ExecutionContext executionContext) {
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,6 +30,11 @@ webprotege:
     timeout: 120000
     event-subscribe: true
   allowedOrigin: webprotege-local.edu
+  sse:
+    # Keep-alive interval; must stay below the nginx proxy_read_timeout (60s) so idle streams survive.
+    heartbeat-interval: 20s
+    # Long-lived stream cap; each reconnect is a fresh authorization checkpoint.
+    stream-timeout: 30m
   minio:
     accessKey: webprotege
     endPoint: http://webprotege-local.edu:9000

--- a/src/test/java/edu/stanford/protege/webprotege/gateway/sse/ProjectEventsSseControllerTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/gateway/sse/ProjectEventsSseControllerTest.java
@@ -1,0 +1,101 @@
+package edu.stanford.protege.webprotege.gateway.sse;
+
+import edu.stanford.protege.webprotege.authorization.ProjectResource;
+import edu.stanford.protege.webprotege.authorization.Subject;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.gateway.websocket.AccessManager;
+import edu.stanford.protege.webprotege.gateway.websocket.dto.BuiltInCapability;
+import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class ProjectEventsSseControllerTest {
+
+    @Mock
+    private SseStreamRegistry registry;
+
+    @Mock
+    private SseCatchUpService catchUpService;
+
+    @Mock
+    private AccessManager accessManager;
+
+    private MockMvc mockMvc;
+
+    private ProjectId projectId;
+
+    @BeforeEach
+    void setUp() {
+        ProjectEventsSseController controller = new ProjectEventsSseController(registry, catchUpService, accessManager);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+        projectId = ProjectId.generate();
+    }
+
+    @Test
+    void returnsForbiddenWhenAccessManagerDenies() throws Exception {
+        when(accessManager.hasPermission(any(), any(), eq(BuiltInCapability.VIEW_PROJECT), any())).thenReturn(false);
+
+        mockMvc.perform(get("/data/projects/{projectId}/events", projectId.id())
+                                .param("userId", "the-user")
+                                .param("token", "the-token")
+                                .accept(MediaType.TEXT_EVENT_STREAM))
+               .andExpect(status().isForbidden());
+
+        verify(registry, never()).subscribe(any(), any(), any());
+    }
+
+    @Test
+    void setsSseHeadersAndSubscribesWhenAuthorized() throws Exception {
+        when(accessManager.hasPermission(any(), any(), eq(BuiltInCapability.VIEW_PROJECT), any())).thenReturn(true);
+        when(registry.subscribe(any(), any(), any())).thenReturn(new SseEmitter());
+
+        mockMvc.perform(get("/data/projects/{projectId}/events", projectId.id())
+                                .param("userId", "the-user")
+                                .param("token", "the-token")
+                                .accept(MediaType.TEXT_EVENT_STREAM))
+               .andExpect(request().asyncStarted())
+               .andExpect(header().string(HttpHeaders.CACHE_CONTROL, "no-cache"))
+               .andExpect(header().string("X-Accel-Buffering", "no"));
+
+        verify(registry).subscribe(eq(projectId), isNull(), any(ExecutionContext.class));
+        verify(accessManager).hasPermission(eq(Subject.forUser("the-user")),
+                                            eq(ProjectResource.forProject(projectId)),
+                                            eq(BuiltInCapability.VIEW_PROJECT),
+                                            any());
+    }
+
+    @Test
+    void prefersLastEventIdHeaderOverQueryParam() throws Exception {
+        when(accessManager.hasPermission(any(), any(), any(), any())).thenReturn(true);
+        when(registry.subscribe(any(), any(), any())).thenReturn(new SseEmitter());
+
+        mockMvc.perform(get("/data/projects/{projectId}/events", projectId.id())
+                                .param("userId", "the-user")
+                                .param("token", "the-token")
+                                .param("lastEventId", "10")
+                                .header("Last-Event-ID", "25")
+                                .accept(MediaType.TEXT_EVENT_STREAM));
+
+        verify(registry).subscribe(eq(projectId), eq("25"), any());
+    }
+}

--- a/src/test/java/edu/stanford/protege/webprotege/gateway/sse/SseStreamRegistryTest.java
+++ b/src/test/java/edu/stanford/protege/webprotege/gateway/sse/SseStreamRegistryTest.java
@@ -1,0 +1,137 @@
+package edu.stanford.protege.webprotege.gateway.sse;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.stanford.protege.webprotege.common.ProjectId;
+import edu.stanford.protege.webprotege.common.UserId;
+import edu.stanford.protege.webprotege.event.EventTag;
+import edu.stanford.protege.webprotege.gateway.websocket.config.ObjectMapperConfiguration;
+import edu.stanford.protege.webprotege.gateway.websocket.dto.EventList;
+import edu.stanford.protege.webprotege.gateway.websocket.dto.ProjectEventsQueryResponse;
+import edu.stanford.protege.webprotege.ipc.ExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter.DataWithMediaType;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter.SseEventBuilder;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SseStreamRegistryTest {
+
+    private SseStreamRegistry registry;
+
+    private ProjectId projectId;
+
+    private ExecutionContext executionContext;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapperConfiguration().objectMapper();
+        SseProperties properties = new SseProperties();
+        // Run fan-out synchronously so sends are observable without waiting on threads.
+        ExecutorService dispatchExecutor = MoreExecutors.newDirectExecutorService();
+        ScheduledExecutorService heartbeatExecutor = mock(ScheduledExecutorService.class);
+        registry = new SseStreamRegistry(objectMapper, properties, dispatchExecutor, heartbeatExecutor);
+        projectId = ProjectId.generate();
+        executionContext = new ExecutionContext(UserId.valueOf("the-user"), "the-token", "correlation");
+    }
+
+    @Test
+    void subscribeRegistersSubscriberAndStoresLastEventId() {
+        registry.subscribe(projectId, "42", executionContext);
+
+        assertEquals(1, registry.subscriberCount(projectId));
+        assertEquals("42", registry.subscribersFor(projectId).get(0).lastEventId());
+    }
+
+    @Test
+    void publishSendsSequenceStampedEventToSubscriber() throws IOException {
+        SseEmitter emitter = mock(SseEmitter.class);
+        registry.register(projectId, emitter, null, executionContext);
+
+        registry.publish(projectId, 7L, response());
+
+        ArgumentCaptor<SseEventBuilder> captor = ArgumentCaptor.forClass(SseEventBuilder.class);
+        verify(emitter).send(captor.capture());
+        String frame = render(captor.getValue());
+        assertTrue(frame.contains("id:7"), frame);
+        assertTrue(frame.contains("event:project-events"), frame);
+        assertTrue(frame.contains("webprotege.hierarchies.GetProjectEvents"), frame);
+    }
+
+    @Test
+    void publishEvictsSubscriberWhenSendFails() throws IOException {
+        SseEmitter emitter = mock(SseEmitter.class);
+        doThrow(new IOException("broken pipe")).when(emitter).send(any(SseEventBuilder.class));
+        registry.register(projectId, emitter, null, executionContext);
+
+        registry.publish(projectId, 1L, response());
+
+        assertEquals(0, registry.subscriberCount(projectId));
+    }
+
+    @Test
+    void heartbeatSendsKeepAliveComment() throws IOException {
+        SseEmitter emitter = mock(SseEmitter.class);
+        registry.register(projectId, emitter, null, executionContext);
+
+        registry.heartbeat();
+
+        ArgumentCaptor<SseEventBuilder> captor = ArgumentCaptor.forClass(SseEventBuilder.class);
+        verify(emitter).send(captor.capture());
+        assertTrue(render(captor.getValue()).contains(":keep-alive"));
+    }
+
+    @Test
+    void heartbeatEvictsSubscriberWhenSendFails() throws IOException {
+        SseEmitter emitter = mock(SseEmitter.class);
+        doThrow(new IOException("broken pipe")).when(emitter).send(any(SseEventBuilder.class));
+        registry.register(projectId, emitter, null, executionContext);
+
+        registry.heartbeat();
+
+        assertEquals(0, registry.subscriberCount(projectId));
+    }
+
+    @Test
+    void completionCallbackEvictsSubscriber() {
+        SseEmitter emitter = mock(SseEmitter.class);
+        registry.register(projectId, emitter, null, executionContext);
+        ArgumentCaptor<Runnable> onCompletion = ArgumentCaptor.forClass(Runnable.class);
+        verify(emitter).onCompletion(onCompletion.capture());
+        assertEquals(1, registry.subscriberCount(projectId));
+
+        onCompletion.getValue().run();
+
+        assertEquals(0, registry.subscriberCount(projectId));
+    }
+
+    private static ProjectEventsQueryResponse response() {
+        ProjectEventsQueryResponse response = new ProjectEventsQueryResponse();
+        response.events = new EventList<>(EventTag.getFirst(), List.of(), EventTag.get(1));
+        return response;
+    }
+
+    private static String render(SseEventBuilder builder) {
+        Set<DataWithMediaType> parts = builder.build();
+        return parts.stream().map(part -> String.valueOf(part.getData())).collect(Collectors.joining());
+    }
+}


### PR DESCRIPTION
Commit 1 of protegeproject/webprotege-gwt-ui#304 (part of protegeproject/webprotege-gwt-ui#303) — the transport skeleton that does not depend on the sequence work.

`GET /data/projects/{projectId}/events` opens a server-sent-events stream. The registry keeps open streams per project, fans payloads out on an executor (never the caller's thread), evicts dead emitters, and heartbeats with comment frames every 20s — under nginx's 60s `proxy_read_timeout`, and on the existing `/data/` route so **no nginx image change is needed** (buffering disabled per-response via `X-Accel-Buffering: no`).

Authorization mirrors the STOMP subscribe check (ViewProject via `AccessManager`), isolated in a single seam that #305 replaces with a short-lived redeemable ticket. `Last-Event-ID` (+ `?lastEventId=` fallback for fresh loads) is plumbed to a catch-up seam; the real replay + broker bridge land next, consuming the sequenced events from protegeproject/webprotege-event-history-service#33.

Tests: 9/9 (JUnit 5 — note this repo silently skips JUnit 4 tests; vintage engine absent). Run under JDK 17.