### PR TITLE
Enable per-instance event queues so each gateway instance sees all project events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>edu.stanford.protege</groupId>
             <artifactId>webprotege-ipc</artifactId>
-            <version>2.0.2</version>
+            <version>2.1.2</version>
         </dependency>
 
         <dependency>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,6 +29,8 @@ webprotege:
     eventsqueue: webprotege-gwt-api-gateway-event-queue
     timeout: 120000
     event-subscribe: true
+    # Each gateway instance pins its own long-lived SSE streams, so every instance must see every event; give each its own queue on the fanout exchange rather than competing on one shared queue.
+    event-queue-per-instance: true
   allowedOrigin: webprotege-local.edu
   sse:
     # Keep-alive interval; must stay below the nginx proxy_read_timeout (60s) so idle streams survive.


### PR DESCRIPTION
Completes protegeproject/webprotege-gwt-ui#307. The mechanism shipped in webprotege-ipc 2.1.2 (protegeproject/webprotege-ipc#33); this turns it on for the gateway and bumps the dependency (no API drift — verified against 2.0.2..2.1.2 for every gateway-facing type; full suite 66/66 on JDK 17).

**Two-instance verification against a live broker** (compose `--scale webprotege-gwt-api-gateway=2`): each replica declared its own exclusive auto-delete queue bound to `webprotege-event-exchange` with one consumer apiece; one published event was delivered to and acknowledged by **both** queues (proven with real project events and a synthetic probe); the per-instance queues vanish with their replica.

**Deploy note:** after the first rollout, the old shared durable queue `webprotege-gwt-api-gateway-event-queue` is left consumer-less and accumulates — delete it once no pre-flag instance remains (observed exactly this during the drill).

**Known, out of scope, epic-flagged:** the RPC *response* queue is still one shared queue, so full gateway scale-out remains blocked on that separate follow-up — confirmed empirically during the drill (RPC replies round-robined to the wrong replica). Events — this ticket's scope — are now instance-complete.